### PR TITLE
Add Universal ECOS Module Template for projects

### DIFF
--- a/Build template
+++ b/Build template
@@ -1,0 +1,103 @@
+To ensure your 13 projects scale as a single organism rather than 13 disjointed startups, you need a **Universal ECOS Module Template**. This structure standardizes how each business connects to the shared "Brain" (Software), "Body" (Hardware), and "Home" (RegenCity).
+
+Below is the **Master Template** you should use to define every project, followed by the **Shared Kernel** that they all inherit.
+
+### **The "ECOS" Universal Build Template**
+
+Copy and fill this for each of the 13 projects. This ensures every business aligns with the technical, physical, and financial architecture.
+
+#### **1. Module Identity**
+*   **Project ID:** `[#1 – #13]`
+*   **Internal Name:** `[e.g., EverLume, AgriConnect]`
+*   **One-Line Pitch:** `[The "X" for "Y"]`
+*   **Complexity Tier:** `[Low (IoT) | Mid (SaaS) | High (Deep Tech)]`
+
+#### **2. The Digital "Brain" (Software)**
+*   **Primary Function:** `[Optimization | Forecasting | Simulation | Control]`
+*   **Specific Logic:** `[e.g., Bayesian failure prediction, LSTM demand forecasting]`
+*   **Key Python Libraries:** `[e.g., Prophet, OR-Tools, OpenMC, PyTorch]`
+*   **Data Inputs:** `[e.g., Humidity, Voltage, Soil pH]`
+*   **Control Outputs:** `[e.g., Valve Open/Close, LED Dim/Bright, Robot Toolpath]`
+
+#### **3. The Physical "Body" (Hardware/IoT)**
+*   **Device Type:** `[e.g., Sensor Node, PLC Controller, Bioreactor, Robot]`
+*   **Edge Compute:** `[ESP32 | Raspberry Pi | Industrial PC]`
+*   **Connectivity:** `[MQTT over WiFi | LoRaWAN | Hardwired Ethernet]`
+*   **Key Sensors:** `[e.g., DHT22, Flow Meter, Spectrometer]`
+
+#### **4. RegenCity Integration (The Lab)**
+*   **Zone Assignment:** `[Zone A (Living) | Zone B (Infra) | Zone C (Ag) | Zone D (R&D)]`
+*   **Physical Role:** `[e.g., Streetlights, Soil Inoculation, Power Baseload]`
+*   **Integration Goal:** `[What does this prove? e.g., "Validates sensor mesh reliability"]`
+
+#### **5. Business Engine**
+*   **Model Type:** `[SaaS | HaaS (Hardware-as-a-Service) | Utility | Licensing]`
+*   **Primary Customer:** `[Commercial Farms | Municipalities | Homeowners]`
+*   **Revenue Stream:** `[e.g., Monthly Subscription, Tipping Fees, Carbon Credits]`
+*   **Unit Economics:** `[e.g., High Margin Software (70%) vs. Volume Hardware (50%)]`
+
+#### **6. Ecosystem Synergy (Inputs/Outputs)**
+*   **Depends On (Input):** `[e.g., Needs Power from #13, Needs Data from #2]`
+*   **Feeds Into (Output):** `[e.g., Provides Waste to #7, Provides Heat to #1]`
+*   **Shared Resource:** `[e.g., Uses the Shared Auth System and Billing Engine]`
+
+#### **7. Build Specs**
+*   **Est. Development Time:** `[Months]`
+*   **Est. MVP Cost:** `[e.g., $60k–$90k]`
+*   **Team Composition:** `[e.g., 1 Firmware Eng + 1 Backend Eng]`
+
+---
+
+### **The Shared "Kernel" (Inherited by All)**
+*Do not rebuild these. All templates above plug into this foundation.*
+
+*   **Repository:** Single Monorepo (Nx/Turborepo).
+*   **Authentication:** Unified Auth0/Web3 Login (One User ID across all apps) [1].
+*   **Database:** Single PostgreSQL Schema (Prisma) with partitions for each project [2][3].
+*   **UI Library:** `@ecosystem/ui-components` (Shared buttons, charts, maps) [4].
+*   **DevOps:** Single CI/CD Pipeline (GitHub Actions $\rightarrow$ AWS ECS) [5].
+*   **Optimization:** `ecosystem-brains` Python library (Shared forecasting/solver logic) [6].
+
+---
+
+### **Applied Examples**
+Here is how three different projects (Low, Mid, and High complexity) fit into this uniform structure.
+
+#### **Example A: Centennial Bulb (#8) – The Infrastructure Layer**
+*   **Identity:** #8 EverLume | "Lighting-as-a-Service" | Tier: Low (IoT)
+*   **The Brain:** **Predictive Maintenance Model**. Uses Bayesian reliability to predict failure years in advance [7].
+*   **The Body:** LED Driver with ESP32 MCU, monitoring voltage/thermal cycles [8].
+*   **RegenCity:** **Zone A & B**. Installed as streetlights and housing illumination. Establishes the mesh network for other sensors [9].
+*   **Business:** **HaaS**. Subscription model ($5–$20/bulb/mo) guaranteeing uptime [10].
+*   **Synergy:**
+    *   *Input:* Power from Micro-Hydro (#13).
+    *   *Output:* IoT mesh backbone for Symbiosis (#2) sensors.
+*   **Specs:** 3–5 Months | $60k–$120k | 1 Firmware + 1 Backend [11].
+
+#### **Example B: Symbiosis (#2) – The Biological Layer**
+*   **Identity:** #2 AgriConnect | "The Soil Operating System" | Tier: Mid (SaaS)
+*   **The Brain:** **Recommendation Engine**. ML (scikit-learn) matches fungal strains to soil data to maximize yield [12].
+*   **The Body:** Soil sensor nodes (Moisture, pH, NPK) connecting via MQTT [13].
+*   **RegenCity:** **Zone C (Farm)**. Inoculates soil to boost initial crop yields by ~30% [14].
+*   **Business:** **Vertical SaaS**. Monthly subscription + hardware lease fees [15].
+*   **Synergy:**
+    *   *Input:* Sensor data pipeline established by #8.
+    *   *Output:* Increased crop yields for Closed-Loop Farm (#3).
+*   **Specs:** 3–5 Months | $60k–$120k | 1 ML Eng + 1 Full Stack [16].
+
+#### **Example C: Geothermal Network (#10) – The Utility Layer**
+*   **Identity:** #10 ThermalGrid | "District Heat Utility" | Tier: High (Infrastructure)
+*   **The Brain:** **Flow & Dispatch Optimizer**. Graph theory (NetworkX) balances heat loads between buildings [17].
+*   **The Body:** PLCs controlling motorized valves and pumps; temperature sensors [18].
+*   **RegenCity:** **Zone A**. Buried loop under the residential zone heating the Foam Homes [19].
+*   **Business:** **Utility**. Long-term heat sales contracts + connection fees [20].
+*   **Synergy:**
+    *   *Input:* Excess electricity from Solar (#12) runs pumps.
+    *   *Output:* Heating/Cooling for Foam Homes (#1).
+*   **Specs:** 5–7 Months | $100k–$180k | 1 Systems Eng + 1 Backend [21].
+
+### **How to Use This Template**
+1.  **Copy the Template** for the remaining 10 projects.
+2.  **Fill in the "Brain"** section using the *Software Build* source data (e.g., for #9 AWG, use "Demand Forecasting with Prophet") [22].
+3.  **Fill in the "RegenCity"** section using the *20-Acre Blueprint* source data [23].
+4.  **Execute Phase 1:** Build the **Shared Kernel** + **Centennial Bulb (#8)** first. This validates the structure before you spend money on the complex reactors.


### PR DESCRIPTION
Introduced a Universal ECOS Module Template to standardize project definitions across 13 projects, detailing aspects like module identity, digital brain, physical body, RegenCity integration, business engine, ecosystem synergy, and build specs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Universal ECOS Module Template to standardize definitions across all 13 projects and align them with a shared software, hardware, and RegenCity framework. This creates a single structure and shared kernel to speed planning and execution.

- **New Features**
  - Master template for identity, software “Brain,” hardware “Body,” RegenCity integration, business model, ecosystem links, and build specs.
  - Shared Kernel guidance: monorepo, unified auth, single Postgres schema, shared UI, CI/CD, and common optimization library.
  - Three applied examples (low/mid/high complexity) to illustrate usage.
  - Short rollout steps to apply the template to the remaining projects.

<sup>Written for commit 8b5239264d7169346de66756d8d6a4685b0ec140. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added ECOS Universal Build Template with standardized structure for 13 projects
  * Includes shared infrastructure guidelines, business engine specifications, and ecosystem integration framework
  * Provided implementation examples at multiple complexity levels with step-by-step setup guidance

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->